### PR TITLE
fix: support '/' character as input from keyboard

### DIFF
--- a/src/app/operations.rs
+++ b/src/app/operations.rs
@@ -73,6 +73,8 @@ impl Calculator {
                 || c == '.'
                 || c == '('
                 || c == ')'
+                || c == '^'
+                || c == '√'
                 || c == '\u{8}'
         }) {
             self.expression = input;


### PR DESCRIPTION
https://github.com/cosmic-utils/calculator/issues/51 Small fix that allows making division straight from keyboard.