### PR TITLE
Text input gets focused when app is focused

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -19,6 +19,7 @@ use cosmic::{
         Alignment, Event, Length, Subscription, event,
         keyboard::Event as KeyEvent,
         keyboard::{Key, Modifiers},
+        window,
     },
     theme,
     widget::{
@@ -65,6 +66,7 @@ pub enum Message {
     Open(String),
     SetDecimalComma(bool),
     Evaluate,
+    Window,
 }
 
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
@@ -538,6 +540,9 @@ impl Application for CosmicCalculator {
                 }
                 self.nav.clear();
             }
+            Message::Window => {
+                return widget::text_input::focus(self.input_id.clone());
+            }
         }
         Task::batch(tasks)
     }
@@ -569,6 +574,7 @@ impl Application for CosmicCalculator {
                 Event::Keyboard(KeyEvent::ModifiersChanged(modifiers)) => {
                     Some(Message::Modifiers(modifiers))
                 }
+                Event::Window(window::Event::Focused) => Some(Message::Window),
                 _ => None,
             }),
             cosmic_config::config_subscription(


### PR DESCRIPTION
Implemented the suggestion from #56. I made when the window gains focus, the text input is now automatically focused.

Added new message "Window" to emit when the Focused event occurs.

While testing this, I noticed an issue: when a button is pressed the text input losses focused. The result is that after pressing a button if then you press a keyboard key will not write the number. The user must press again the text input to write. Maybe the text input should be always focused whatever the case or when there is nothing above the main view(number pud)?

Feedback on the preferred behavior would be appreciated.