### PR TITLE
Guard empty-expression eval and widen input validation

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -2,7 +2,7 @@
 
 use std::any::TypeId;
 use std::collections::HashMap;
-use std::process::Command;
+use std::process::{Command, Stdio};
 
 use crate::app::{config::CONFIG_VERSION, operations::Calculator, operator::Operator};
 use crate::core::{icons, key_binds::key_binds};
@@ -435,7 +435,16 @@ impl Application for CosmicCalculator {
                 }
             }
             Message::Evaluate => {
+                // Guard: evaluating an empty/blank expression drops qalc into
+                // interactive mode, which either hangs waiting on stdin or
+                // returns its "> " prompt as a bogus result. Do nothing here.
+                if self.calculator.expression.trim().is_empty() {
+                    return Task::batch(tasks);
+                }
+
                 let mut command = Command::new("qalc");
+                // Never let qalc block waiting on stdin.
+                command.stdin(Stdio::null());
                 command.args(["-t"]);
                 command.args(["-u8"]);
                 command.args(["-set", "maxdeci 9"]);
@@ -460,23 +469,32 @@ impl Application for CosmicCalculator {
                     return Task::batch(tasks);
                 };
 
-                let error = String::from_utf8(output.stderr).unwrap_or_default();
-                if !error.is_empty() {
-                    tracing::error!("An error ocurred: {}", error);
-                    tasks.push(self.update(Message::ShowToast("An error ocurred".to_string())));
-                    return Task::batch(tasks);
-                }
-
                 let outcome = String::from_utf8(output.stdout)
                     .unwrap_or_default()
-                    .replace(['\n', '\r'], "");
+                    .replace(['\n', '\r'], "")
+                    // Strip any stray interactive-prompt artifact.
+                    .replace("> ", "")
+                    .trim()
+                    .to_string();
+
+                // qalc prints informational warnings to stderr even when it
+                // produces a perfectly good result on stdout, so a non-empty
+                // stderr is NOT by itself an error. Only treat the run as
+                // failed when there is no usable result on stdout.
                 if outcome.is_empty() {
-                    tracing::error!("Failed to parse qalc output");
-                    tasks.push(self.update(Message::ShowToast(
-                        "Failed to parse qalc output".to_string(),
-                    )));
+                    let error = String::from_utf8(output.stderr).unwrap_or_default();
+                    if error.is_empty() {
+                        tracing::error!("Failed to parse qalc output");
+                        tasks.push(self.update(Message::ShowToast(
+                            "Failed to parse qalc output".to_string(),
+                        )));
+                    } else {
+                        tracing::error!("An error occurred: {}", error);
+                        tasks
+                            .push(self.update(Message::ShowToast("An error occurred".to_string())));
+                    }
                     return Task::batch(tasks);
-                };
+                }
 
                 self.calculator.outcome = outcome.clone();
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -435,9 +435,7 @@ impl Application for CosmicCalculator {
                 }
             }
             Message::Evaluate => {
-                // Guard: evaluating an empty/blank expression drops qalc into
-                // interactive mode, which either hangs waiting on stdin or
-                // returns its "> " prompt as a bogus result. Do nothing here.
+                // An empty expression drops qalc into interactive mode, which hangs.
                 if self.calculator.expression.trim().is_empty() {
                     return Task::batch(tasks);
                 }
@@ -477,10 +475,8 @@ impl Application for CosmicCalculator {
                     .trim()
                     .to_string();
 
-                // qalc prints informational warnings to stderr even when it
-                // produces a perfectly good result on stdout, so a non-empty
-                // stderr is NOT by itself an error. Only treat the run as
-                // failed when there is no usable result on stdout.
+                // qalc writes warnings to stderr even on success, so only treat the
+                // run as failed when stdout has no usable result.
                 if outcome.is_empty() {
                     let error = String::from_utf8(output.stderr).unwrap_or_default();
                     if error.is_empty() {

--- a/src/app/operations.rs
+++ b/src/app/operations.rs
@@ -62,21 +62,33 @@ impl Calculator {
     }
 
     pub(crate) fn on_input(&mut self, input: String) {
+        // qalc is the real parser/sandbox and safely handles arbitrary
+        // expressions (functions, constants, units, factorials, etc.) by
+        // returning them unevaluated rather than crashing. Keep only a light
+        // guard so we don't blanket-reject useful input. Notably this now
+        // permits letters (sin, sqrt, pi, e ...), whitespace, '!' for
+        // factorials, and ',' which is required to type decimals in
+        // decimal-comma locales.
         if input.chars().all(|c| {
-            c.is_ascii_digit()
-                || c == '+'
-                || c == '-'
-                || c == '*'
-                || c == '/'
-                || c == '÷'
-                || c == '/'
-                || c == '%'
-                || c == '.'
-                || c == '('
-                || c == ')'
-                || c == '^'
-                || c == '√'
-                || c == '\u{8}'
+            c.is_alphanumeric()
+                || c.is_whitespace()
+                || matches!(
+                    c,
+                    '+' | '-'
+                        | '*'
+                        | '/'
+                        | '÷'
+                        | '×'
+                        | '%'
+                        | '.'
+                        | ','
+                        | '('
+                        | ')'
+                        | '^'
+                        | '√'
+                        | '!'
+                        | '\u{8}'
+                )
         }) {
             self.expression = input;
         }
@@ -116,5 +128,5 @@ pub fn autocalc() -> bool {
     let min_version = Version::parse("5.4.0").unwrap();
     qalc_version()
         .and_then(|version| Version::parse(&version).ok())
-        .map_or(false, |current| current >= min_version)
+        .is_some_and(|current| current >= min_version)
 }

--- a/src/app/operations.rs
+++ b/src/app/operations.rs
@@ -62,13 +62,8 @@ impl Calculator {
     }
 
     pub(crate) fn on_input(&mut self, input: String) {
-        // qalc is the real parser/sandbox and safely handles arbitrary
-        // expressions (functions, constants, units, factorials, etc.) by
-        // returning them unevaluated rather than crashing. Keep only a light
-        // guard so we don't blanket-reject useful input. Notably this now
-        // permits letters (sin, sqrt, pi, e ...), whitespace, '!' for
-        // factorials, and ',' which is required to type decimals in
-        // decimal-comma locales.
+        // qalc validates the expression itself, so keep this filter permissive:
+        // allow letters (sin, pi), whitespace, '!', and ',' for decimal-comma locales.
         if input.chars().all(|c| {
             c.is_alphanumeric()
                 || c.is_whitespace()


### PR DESCRIPTION
## What

Three related fixes around the qalc evaluation path and keyboard input handling.

### 1. Empty-expression evaluation
Evaluating a blank expression invoked `qalc` with no input, which drops it into interactive mode — it either hangs waiting on stdin or returns its `> ` prompt as a bogus result. This now returns early on blank input, and additionally sets `Stdio::null()` so qalc can never block on stdin.

### 2. stderr is no longer treated as fatal on its own
qalc can print informational warnings to stderr while still producing a perfectly good result on stdout. The previous code discarded the result and showed an error toast whenever stderr was non-empty. Now stderr is only consulted when stdout has no usable result, and the toast distinguishes "no output" from an actual error message. Stray `> ` prompt artifacts are also stripped from the output.

### 3. Wider input validation
The keyboard input filter rejected letters, whitespace, `!`, `,` and `×`. qalc is the real parser and safely handles arbitrary expressions, so the filter was needlessly blocking valid input. It now permits letters (functions/constants like `sin`, `sqrt`, `pi`), whitespace, `!` (factorial), `,` (required for decimals in decimal-comma locales) and `×`.

## Testing
- `cargo check` passes.
- Verified against qalc 4.9.0 that a blank expression yields the `> ` artifact (now guarded), and that `5!` evaluates to `120` (now typeable).