### PR TITLE
GUI improvements:  keypad and history sidebar

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -48,6 +48,7 @@ pub struct CosmicCalculator {
     calculator: Calculator,
     toasts: widget::Toasts<Message>,
     input_id: widget::Id,
+    button_font_size: f32,
 }
 
 #[derive(Debug, Clone)]
@@ -68,6 +69,7 @@ pub enum Message {
     SetDecimalComma(bool),
     Evaluate,
     Window,
+    Resized(cosmic::iced::Size),
 }
 
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
@@ -149,7 +151,7 @@ impl Application for CosmicCalculator {
 
         for entry in &flags.config.history {
             nav.insert()
-                .text(entry.expression.clone())
+                .text(history_label(&entry.expression))
                 .data(entry.clone());
         }
 
@@ -183,6 +185,7 @@ impl Application for CosmicCalculator {
             calculator: Calculator::new(),
             toasts: widget::toaster::Toasts::new(Message::CloseToast),
             input_id: widget::Id::unique(),
+            button_font_size: 20.0,
         };
 
         let mut tasks = vec![];
@@ -252,18 +255,26 @@ impl Application for CosmicCalculator {
             .push(
                 widget::column::with_capacity(6)
                     .push(
-                        widget::row::with_capacity(3)
-                            .push(standard_button(
+                        widget::row::with_capacity(4)
+                            .push(destructive_button(
                                 Message::Operator(Operator::Clear),
-                                Length::FillPortion(2),
+                                Length::FillPortion(1),
+                                self.button_font_size,
+                            ))
+                            .push(standard_button(
+                                Message::Operator(Operator::Negate),
+                                Length::FillPortion(1),
+                                self.button_font_size,
                             ))
                             .push(standard_button(
                                 Message::Operator(Operator::Modulus),
                                 Length::FillPortion(1),
+                                self.button_font_size,
                             ))
                             .push(suggested_button(
-                                Message::Operator(Operator::Divide),
+                                Message::Operator(Operator::Power),
                                 Length::FillPortion(1),
+                                self.button_font_size,
                             ))
                             .width(Length::Fill)
                             .height(Length::Fill)
@@ -274,18 +285,22 @@ impl Application for CosmicCalculator {
                             .push(standard_button(
                                 Message::Operator(Operator::ParenthesesOpen),
                                 Length::FillPortion(1),
+                                self.button_font_size,
                             ))
                             .push(standard_button(
                                 Message::Operator(Operator::ParenthesesClose),
                                 Length::FillPortion(1),
+                                self.button_font_size,
                             ))
                             .push(standard_button(
                                 Message::Operator(Operator::SquareRoot),
                                 Length::FillPortion(1),
+                                self.button_font_size,
                             ))
                             .push(suggested_button(
-                                Message::Operator(Operator::Power),
+                                Message::Operator(Operator::Divide),
                                 Length::FillPortion(1),
+                                self.button_font_size,
                             ))
                             .width(Length::Fill)
                             .height(Length::Fill)
@@ -293,21 +308,25 @@ impl Application for CosmicCalculator {
                     )
                     .push(
                         widget::row::with_capacity(4)
-                            .push(standard_button(
+                            .push(text_button(
                                 Message::Number(7.0),
                                 Length::FillPortion(1),
+                                self.button_font_size,
                             ))
-                            .push(standard_button(
+                            .push(text_button(
                                 Message::Number(8.0),
                                 Length::FillPortion(1),
+                                self.button_font_size,
                             ))
-                            .push(standard_button(
+                            .push(text_button(
                                 Message::Number(9.0),
                                 Length::FillPortion(1),
+                                self.button_font_size,
                             ))
                             .push(suggested_button(
                                 Message::Operator(Operator::Multiply),
                                 Length::FillPortion(1),
+                                self.button_font_size,
                             ))
                             .width(Length::Fill)
                             .height(Length::Fill)
@@ -315,21 +334,25 @@ impl Application for CosmicCalculator {
                     )
                     .push(
                         widget::row::with_capacity(4)
-                            .push(standard_button(
+                            .push(text_button(
                                 Message::Number(4.0),
                                 Length::FillPortion(1),
+                                self.button_font_size,
                             ))
-                            .push(standard_button(
+                            .push(text_button(
                                 Message::Number(5.0),
                                 Length::FillPortion(1),
+                                self.button_font_size,
                             ))
-                            .push(standard_button(
+                            .push(text_button(
                                 Message::Number(6.0),
                                 Length::FillPortion(1),
+                                self.button_font_size,
                             ))
                             .push(suggested_button(
                                 Message::Operator(Operator::Subtract),
                                 Length::FillPortion(1),
+                                self.button_font_size,
                             ))
                             .width(Length::Fill)
                             .height(Length::Fill)
@@ -337,21 +360,25 @@ impl Application for CosmicCalculator {
                     )
                     .push(
                         widget::row::with_capacity(4)
-                            .push(standard_button(
+                            .push(text_button(
                                 Message::Number(1.0),
                                 Length::FillPortion(1),
+                                self.button_font_size,
                             ))
-                            .push(standard_button(
+                            .push(text_button(
                                 Message::Number(2.0),
                                 Length::FillPortion(1),
+                                self.button_font_size,
                             ))
-                            .push(standard_button(
+                            .push(text_button(
                                 Message::Number(3.0),
                                 Length::FillPortion(1),
+                                self.button_font_size,
                             ))
                             .push(suggested_button(
                                 Message::Operator(Operator::Add),
                                 Length::FillPortion(1),
+                                self.button_font_size,
                             ))
                             .width(Length::Fill)
                             .height(Length::Fill)
@@ -359,21 +386,25 @@ impl Application for CosmicCalculator {
                     )
                     .push(
                         widget::row::with_capacity(4)
-                            .push(standard_button(
+                            .push(text_button(
                                 Message::Number(0.0),
                                 Length::FillPortion(1),
+                                self.button_font_size,
                             ))
-                            .push(standard_button(
+                            .push(text_button(
                                 Message::Operator(Operator::Point),
                                 Length::FillPortion(1),
+                                self.button_font_size,
                             ))
                             .push(standard_button(
                                 Message::Operator(Operator::Backspace),
                                 Length::FillPortion(1),
+                                self.button_font_size,
                             ))
                             .push(suggested_button(
                                 Message::Operator(Operator::Equal),
                                 Length::FillPortion(1),
+                                self.button_font_size,
                             ))
                             .width(Length::Fill)
                             .height(Length::Fill)
@@ -507,7 +538,7 @@ impl Application for CosmicCalculator {
                 }
                 self.nav
                     .insert()
-                    .text(self.calculator.expression.clone())
+                    .text(history_label(&self.calculator.expression))
                     .data(self.calculator.clone());
 
                 self.calculator.expression = outcome;
@@ -523,7 +554,7 @@ impl Application for CosmicCalculator {
                 if modifiers.control() || modifiers.alt() || modifiers.logo() {
                     return Task::batch(tasks);
                 }
-                
+
                 // Calculator input even when the text input is unfocused (covers the numpad).
                 match key {
                     Key::Character(c) => {
@@ -542,7 +573,7 @@ impl Application for CosmicCalculator {
                         if let Some(operator) = operator {
                             return self.update(Message::Operator(operator));
                         }
-                        
+
                         // Digits and decimal separators reuse on_input validation.
                         if !c.is_empty()
                             && c.chars()
@@ -604,6 +635,10 @@ impl Application for CosmicCalculator {
             Message::Window => {
                 return widget::text_input::focus(self.input_id.clone());
             }
+            Message::Resized(size) => {
+                // Scale button labels with the window height.
+                self.button_font_size = (size.height / 22.0).clamp(10.0, 48.0);
+            }
         }
         Task::batch(tasks)
     }
@@ -636,6 +671,7 @@ impl Application for CosmicCalculator {
                     Some(Message::Modifiers(modifiers))
                 }
                 Event::Window(window::Event::Focused) => Some(Message::Window),
+                Event::Window(window::Event::Resized(size)) => Some(Message::Resized(size)),
                 _ => None,
             }),
             cosmic_config::config_subscription(
@@ -680,22 +716,50 @@ impl CosmicCalculator {
     }
 }
 
-pub fn standard_button<'a>(message: Message, width: Length) -> Element<'a, Message> {
+// Sidebar label: expression truncated to fit the sidebar width.
+fn history_label(expression: &str) -> String {
+    const MAX: usize = 28;
+    if expression.chars().count() > MAX {
+        expression.chars().take(MAX).collect::<String>() + "…"
+    } else {
+        expression.to_string()
+    }
+}
+
+pub fn standard_button<'a>(message: Message, width: Length, font_size: f32) -> Element<'a, Message> {
     let label = match message.clone() {
         Message::Number(num) => num.to_string(),
         Message::Operator(operator) => operator.display().to_string(),
         _ => String::new(),
     };
-    button(label, message, theme::Button::Standard, width)
+    button(label, message, theme::Button::Standard, width, font_size)
 }
 
-pub fn suggested_button<'a>(message: Message, width: Length) -> Element<'a, Message> {
+pub fn suggested_button<'a>(message: Message, width: Length, font_size: f32) -> Element<'a, Message> {
     let label = match &message {
         Message::Number(num) => num.to_string(),
         Message::Operator(operator) => operator.display().to_string(),
         _ => String::new(),
     };
-    button(label.to_string(), message, theme::Button::Suggested, width)
+    button(label.to_string(), message, theme::Button::Suggested, width, font_size)
+}
+
+pub fn destructive_button<'a>(message: Message, width: Length, font_size: f32) -> Element<'a, Message> {
+    let label = match &message {
+        Message::Number(num) => num.to_string(),
+        Message::Operator(operator) => operator.display().to_string(),
+        _ => String::new(),
+    };
+    button(label.to_string(), message, theme::Button::Destructive, width, font_size)
+}
+
+pub fn text_button<'a>(message: Message, width: Length, font_size: f32) -> Element<'a, Message> {
+    let label = match &message {
+        Message::Number(num) => num.to_string(),
+        Message::Operator(operator) => operator.display().to_string(),
+        _ => String::new(),
+    };
+    button(label.to_string(), message, theme::Button::Text, width, font_size)
 }
 
 pub fn button<'a>(
@@ -703,14 +767,17 @@ pub fn button<'a>(
     message: Message,
     style: theme::Button,
     width: Length,
+    font_size: f32,
 ) -> Element<'a, Message> {
     widget::button::custom(
-        widget::container(widget::text(label).size(20.0))
+        widget::container(widget::text(label).size(font_size).line_height(1.0))
             .center(Length::Fill)
             .width(Length::Fill)
             .height(Length::Fill),
     )
     .class(style)
+    // Class padding off-centers glyphs on small buttons; the container centers.
+    .padding(0)
     .width(width)
     .height(Length::Fill)
     .on_press(message)

--- a/src/app/operations.rs
+++ b/src/app/operations.rs
@@ -49,6 +49,7 @@ impl Calculator {
             Operator::Power => self.add_operator(Operator::Power),
             Operator::SquareRoot => self.add_operator(Operator::SquareRoot),
             Operator::Clear => self.clear(),
+            Operator::Negate => self.toggle_sign(),
             Operator::Equal => return Some(Message::Evaluate),
             Operator::Backspace => {
                 self.expression.pop();
@@ -56,6 +57,34 @@ impl Calculator {
         };
         None
     }
+    pub fn toggle_sign(&mut self) {
+        // Start index of the trailing number, if the expression ends with one.
+        let Some(num_start) = self
+            .expression
+            .char_indices()
+            .rev()
+            .take_while(|(_, c)| c.is_ascii_digit() || *c == '.' || *c == ',')
+            .last()
+            .map(|(i, _)| i)
+        else {
+            return; // empty or not ending in a number: nothing to negate
+        };
+
+        let before = &self.expression[..num_start];
+        // A '-' is unary at the start or right after an operator or '('.
+        let is_unary_minus = before.ends_with('-')
+            && matches!(
+                before[..before.len() - 1].chars().next_back(),
+                None | Some('+' | '-' | '*' | '/' | '×' | '÷' | '%' | '^' | '(')
+            );
+
+        if is_unary_minus {
+            self.expression.remove(num_start - 1);
+        } else {
+            self.expression.insert(num_start, '-');
+        }
+    }
+
     pub fn clear(&mut self) {
         self.expression.clear();
         self.outcome = String::new();

--- a/src/app/operator.rs
+++ b/src/app/operator.rs
@@ -9,6 +9,7 @@ pub enum Operator {
     Equal,
     Clear,
     Backspace,
+    Negate,
     ParenthesesOpen,
     ParenthesesClose,
     Power,
@@ -31,6 +32,7 @@ impl Operator {
             Self::SquareRoot => "√",
             Self::Clear => "C",
             Self::Backspace => "⌫",
+            Self::Negate => "±",
         }
     }
 
@@ -49,6 +51,7 @@ impl Operator {
             Self::SquareRoot => "√",
             Self::Clear => "C",
             Self::Backspace => "⌫",
+            Self::Negate => "±",
         }
     }
 }


### PR DESCRIPTION
**Summary**
This PR improves the calculator's visual design: a more logical operator layout, semantic button colors, labels that scale with the window, and a fix for history entries overflowing the sidebar. It also adds a sign toggle (±) button.
This lays the groundwork for a future scientific mode, which will benefit from a more complex, adaptive GUI that stays harmonized with the standard mode.

**1. New sign toggle (±) button**
Toggles the sign of the last number in the expression: 3 → -3, 5+3 → 5+-3 (evaluates to 2). It correctly distinguishes unary from binary minus, so pressing it twice always returns to the original expression, and it only affects the current number — never the rest of the equation. It does nothing when the expression is empty or doesn't end with a number. The first row becomes C ± % ^, making all rows uniform 4-button rows now that C is no longer double-width.

**2. Basic operators grouped in the accent column**
^ and ÷ swap positions. The accent column now reads ^ ÷ × − + = top to bottom: the four basic operations sit contiguously above = (the familiar phone-calculator pattern), with power at the top among the other one-shot functions (%, ±).

**3. Semantic button classes**
C → theme::Button::Destructive (themed red — clearing is the destructive action). Digits and . → theme::Button::Text (flat), so the eye immediately finds the two key actions: = (accent) and C (red). Everything stays fully themed — all colors come from the system theme; nothing is hardcoded.

**4. Adaptive button label size + glyph centering fix**
Labels previously used a fixed 20px size, which looked lost on large windows and overflowed small buttons. They now scale with window height (height / 22, clamped to 10–48px). This also exposed a pre-existing bug: the fixed vertical padding in button styles pushed glyphs off-center on small buttons — fixed with padding(0) and line_height(1.0), letting the inner container do the centering (applies to all button classes).

**5. Truncate long history entries**
Long expressions overflowed past the sidebar boundary (visible with the window maximized, where the sidebar is expanded). Entries are now truncated to ~28 characters with …. Stored data is unchanged — clicking an entry still restores the full result. This is an existing issue, visible whenever Calculator is maximized.