### PR TITLE
Add scientific mode and fix decimal-comma locale keypad bug

### DIFF
--- a/i18n/en/cosmic_ext_calculator.ftl
+++ b/i18n/en/cosmic_ext_calculator.ftl
@@ -5,6 +5,9 @@ delete = Delete
 clear-history = Clear history
 malformed-expression = Malformed expression
 
+basic-mode = Basic Mode
+scientific-mode = Scientific Mode
+
 ## About
 repository = Repository
 support = Support

--- a/i18n/pt-BR/cosmic_ext_calculator.ftl
+++ b/i18n/pt-BR/cosmic_ext_calculator.ftl
@@ -5,6 +5,9 @@ delete = Excluir
 clear-history = Limpar histórico
 malformed-expression = Expressão malformada
 
+basic-mode = Modo Básico
+scientific-mode = Modo Científico
+
 ## About
 repository = Repositório
 support = Suporte

--- a/src/app.rs
+++ b/src/app.rs
@@ -49,7 +49,7 @@ pub struct CosmicCalculator {
     toasts: widget::Toasts<Message>,
     input_id: widget::Id,
     button_font_size: f32,
-    scientific_mode: bool,
+    mode: Mode,
 }
 
 #[derive(Debug, Clone)]
@@ -71,7 +71,7 @@ pub enum Message {
     Evaluate,
     Window,
     Resized(cosmic::iced::Size),
-    ToggleScientificMode,
+    Toggle(Mode),
 }
 
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
@@ -90,7 +90,13 @@ pub struct Flags {
 pub enum MenuAction {
     About,
     ClearHistory,
-    ToggleScientificMode,
+    Toggle(Mode),
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Mode {
+    Basic,
+    Scientific
 }
 
 impl menu::action::MenuAction for MenuAction {
@@ -100,7 +106,7 @@ impl menu::action::MenuAction for MenuAction {
         match self {
             MenuAction::About => Message::ToggleContextPage(ContextPage::About),
             MenuAction::ClearHistory => Message::CleanHistory,
-            MenuAction::ToggleScientificMode => Message::ToggleScientificMode,
+            MenuAction::Toggle(mode) => Message::Toggle(*mode),
         }
     }
 }
@@ -226,7 +232,7 @@ impl Application for CosmicCalculator {
             toasts: widget::toaster::Toasts::new(Message::CloseToast),
             input_id: widget::Id::unique(),
             button_font_size: 20.0,
-            scientific_mode: false,
+            mode: Mode::Basic, // Defaults to basic mode
         };
 
         let mut tasks = vec![];
@@ -242,10 +248,16 @@ impl Application for CosmicCalculator {
     }
 
     fn header_start<'a>(&'a self) -> Vec<Element<'a, Self::Message>> {
-        let scientific_label = if self.scientific_mode {
-            fl!("basic-mode")
-        } else {
-            fl!("scientific-mode")
+        // If the current mode is basic, the button switches to scientific mode, and vice-versa
+
+        let scientific_label = match self.mode {
+            Mode::Basic => fl!("scientific-mode"),
+            Mode::Scientific => fl!("basic-mode"),
+        };
+
+        let toggle = match self.mode {
+            Mode::Basic => MenuAction::Toggle(Mode::Scientific),
+            Mode::Scientific => MenuAction::Toggle(Mode::Basic),
         };
 
         let menu_bar = menu::bar(vec![menu::Tree::with_children(
@@ -256,7 +268,7 @@ impl Application for CosmicCalculator {
                     menu::Item::Button(
                         scientific_label,
                         Some(icons::get_handle("settings-symbolic", 14)),
-                        MenuAction::ToggleScientificMode,
+                        toggle,
                     ),
                     menu::Item::Button(
                         fl!("clear-history"),
@@ -298,11 +310,16 @@ impl Application for CosmicCalculator {
     fn view<'a>(&'a self) -> Element<'a, Self::Message> {
         let spacing = cosmic::theme::active().cosmic().spacing;
 
-        // Build the keypad column
-        let mut keypad = widget::column::with_capacity(if self.scientific_mode { 11 } else { 7 });
+        // Build the keypad column with more rows in scientific mode
+        let mut keypad = widget::column::with_capacity(
+            match self.mode {
+                Mode::Basic => 7,
+                Mode::Scientific => 11,
+            }
+        );
 
         // Scientific buttons at the top of the keypad
-        if self.scientific_mode {
+        if self.mode == Mode::Scientific {
             keypad = keypad
                 .push(
                     widget::row::with_capacity(4)
@@ -653,7 +670,7 @@ impl Application for CosmicCalculator {
             Message::Resized(size) => {
                 self.button_font_size = (size.height / 22.0).clamp(10.0, 48.0);
             }
-            Message::ToggleScientificMode => self.scientific_mode = !self.scientific_mode,
+            Message::Toggle(mode) => self.mode = mode,
         }
         Task::batch(tasks)
     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -49,6 +49,7 @@ pub struct CosmicCalculator {
     toasts: widget::Toasts<Message>,
     input_id: widget::Id,
     button_font_size: f32,
+    scientific_mode: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -70,6 +71,7 @@ pub enum Message {
     Evaluate,
     Window,
     Resized(cosmic::iced::Size),
+    ToggleScientificMode,
 }
 
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
@@ -88,6 +90,7 @@ pub struct Flags {
 pub enum MenuAction {
     About,
     ClearHistory,
+    ToggleScientificMode,
 }
 
 impl menu::action::MenuAction for MenuAction {
@@ -97,6 +100,7 @@ impl menu::action::MenuAction for MenuAction {
         match self {
             MenuAction::About => Message::ToggleContextPage(ContextPage::About),
             MenuAction::ClearHistory => Message::CleanHistory,
+            MenuAction::ToggleScientificMode => Message::ToggleScientificMode,
         }
     }
 }
@@ -222,6 +226,7 @@ impl Application for CosmicCalculator {
             toasts: widget::toaster::Toasts::new(Message::CloseToast),
             input_id: widget::Id::unique(),
             button_font_size: 20.0,
+            scientific_mode: false,
         };
 
         let mut tasks = vec![];
@@ -237,11 +242,22 @@ impl Application for CosmicCalculator {
     }
 
     fn header_start<'a>(&'a self) -> Vec<Element<'a, Self::Message>> {
+        let scientific_label = if self.scientific_mode {
+            fl!("basic-mode")
+        } else {
+            fl!("scientific-mode")
+        };
+
         let menu_bar = menu::bar(vec![menu::Tree::with_children(
             RcElementWrapper::new(menu::root(fl!("view")).into()),
             menu::items(
                 &self.key_binds,
                 vec![
+                    menu::Item::Button(
+                        scientific_label,
+                        Some(icons::get_handle("settings-symbolic", 14)),
+                        MenuAction::ToggleScientificMode,
+                    ),
                     menu::Item::Button(
                         fl!("clear-history"),
                         Some(icons::get_handle("large-brush-symbolic", 14)),
@@ -282,6 +298,125 @@ impl Application for CosmicCalculator {
     fn view<'a>(&'a self) -> Element<'a, Self::Message> {
         let spacing = cosmic::theme::active().cosmic().spacing;
 
+        // Build the keypad column
+        let mut keypad = widget::column::with_capacity(if self.scientific_mode { 11 } else { 7 });
+
+        // Scientific buttons at the top of the keypad
+        if self.scientific_mode {
+            keypad = keypad
+                .push(
+                    widget::row::with_capacity(4)
+                        .push(self.button(Message::Operator(Operator::Log), theme::Button::Standard))
+                        .push(self.button(Message::Operator(Operator::Ln), theme::Button::Standard))
+                        .push(self.button(Message::Operator(Operator::Log2), theme::Button::Standard))
+                        .push(self.button(Message::Operator(Operator::Factorial), theme::Button::Standard))
+                        .width(Length::Fill)
+                        .height(Length::Fill)
+                        .spacing(spacing.space_xs),
+                )
+                .push(
+                    widget::row::with_capacity(4)
+                        .push(self.button(Message::Operator(Operator::Sin), theme::Button::Standard))
+                        .push(self.button(Message::Operator(Operator::Cos), theme::Button::Standard))
+                        .push(self.button(Message::Operator(Operator::Tan), theme::Button::Standard))
+                        .push(self.button(Message::Operator(Operator::Comma), theme::Button::Standard))
+                        .width(Length::Fill)
+                        .height(Length::Fill)
+                        .spacing(spacing.space_xs),
+                )
+                .push(
+                    widget::row::with_capacity(4)
+                        .push(self.button(Message::Operator(Operator::Asin), theme::Button::Standard))
+                        .push(self.button(Message::Operator(Operator::Acos), theme::Button::Standard))
+                        .push(self.button(Message::Operator(Operator::Atan), theme::Button::Standard))
+                        .push(self.button(Message::Operator(Operator::Reciprocal), theme::Button::Standard))
+                        .width(Length::Fill)
+                        .height(Length::Fill)
+                        .spacing(spacing.space_xs),
+                )
+                .push(
+                    widget::row::with_capacity(4)
+                        .push(self.button(Message::Operator(Operator::E), theme::Button::Standard))
+                        .push(self.button(Message::Operator(Operator::Pi), theme::Button::Standard))
+                        .width(Length::Fill)
+                        .height(Length::Fill)
+                        .spacing(spacing.space_xs),
+                );
+        }
+
+        // Standard buttons and toaster to the keypad
+        keypad = keypad
+            .push(
+                widget::row::with_capacity(4)
+                    .push(self.button(Message::Operator(Operator::Clear), theme::Button::Destructive))
+                    .push(self.button(Message::Operator(Operator::Negate), theme::Button::Standard))
+                    .push(self.button(Message::Operator(Operator::Modulus), theme::Button::Standard))
+                    .push(self.button(Message::Operator(Operator::Power), theme::Button::Suggested))
+                    .width(Length::Fill)
+                    .height(Length::Fill)
+                    .spacing(spacing.space_xs),
+            )
+            .push(
+                widget::row::with_capacity(4)
+                    .push(self.button(Message::Operator(Operator::ParenthesesOpen), theme::Button::Standard))
+                    .push(self.button(Message::Operator(Operator::ParenthesesClose), theme::Button::Standard))
+                    .push(self.button(Message::Operator(Operator::SquareRoot), theme::Button::Standard))
+                    .push(self.button(Message::Operator(Operator::Divide), theme::Button::Suggested))
+                    .width(Length::Fill)
+                    .height(Length::Fill)
+                    .spacing(spacing.space_xs),
+            )
+            .push(
+                widget::row::with_capacity(4)
+                    .push(self.button(Message::Number(7.0), theme::Button::Text))
+                    .push(self.button(Message::Number(8.0), theme::Button::Text))
+                    .push(self.button(Message::Number(9.0), theme::Button::Text))
+                    .push(self.button(Message::Operator(Operator::Multiply), theme::Button::Suggested))
+                    .width(Length::Fill)
+                    .height(Length::Fill)
+                    .spacing(spacing.space_xs),
+            )
+            .push(
+                widget::row::with_capacity(4)
+                    .push(self.button(Message::Number(4.0), theme::Button::Text))
+                    .push(self.button(Message::Number(5.0), theme::Button::Text))
+                    .push(self.button(Message::Number(6.0), theme::Button::Text))
+                    .push(self.button(Message::Operator(Operator::Subtract), theme::Button::Suggested))
+                    .width(Length::Fill)
+                    .height(Length::Fill)
+                    .spacing(spacing.space_xs),
+            )
+            .push(
+                widget::row::with_capacity(4)
+                    .push(self.button(Message::Number(1.0), theme::Button::Text))
+                    .push(self.button(Message::Number(2.0), theme::Button::Text))
+                    .push(self.button(Message::Number(3.0), theme::Button::Text))
+                    .push(self.button(Message::Operator(Operator::Add), theme::Button::Suggested))
+                    .width(Length::Fill)
+                    .height(Length::Fill)
+                    .spacing(spacing.space_xs),
+            )
+            .push(
+                widget::row::with_capacity(4)
+                    .push(self.button(Message::Number(0.0), theme::Button::Text))
+                    .push(self.button(Message::Operator(Operator::Point), theme::Button::Text))
+                    .push(self.button(Message::Operator(Operator::Backspace), theme::Button::Destructive))
+                    .push(self.button(Message::Operator(Operator::Equal), theme::Button::Suggested))
+                    .width(Length::Fill)
+                    .height(Length::Fill)
+                    .spacing(spacing.space_xs),
+            )
+            .push(widget::row(vec![widget::toaster(
+                &self.toasts,
+                widget::space::horizontal(),
+            )]))
+            .max_width(1000.0)
+            .width(Length::Fill)
+            .height(Length::Fill)
+            .align_x(Alignment::Center)
+            .spacing(spacing.space_xs);
+
+        // Final outer column combining the input field and the completed keypad
         widget::column::with_capacity(2)
             .push(
                 widget::text_input("", &self.calculator.expression)
@@ -291,124 +426,7 @@ impl Application for CosmicCalculator {
                     .size(32.0)
                     .width(Length::Fill),
             )
-            .push(
-                widget::column::with_capacity(6)
-                    .push(
-                        widget::row::with_capacity(4)
-                            .push(self.button(
-                                Message::Operator(Operator::Clear),
-                                theme::Button::Destructive,
-                            ))
-                            .push(self.button(
-                                Message::Operator(Operator::Negate),
-                                theme::Button::Standard,
-                            ))
-                            .push(self.button(
-                                Message::Operator(Operator::Modulus),
-                                theme::Button::Standard,
-                            ))
-                            .push(self.button(
-                                Message::Operator(Operator::Power),
-                                theme::Button::Suggested,
-                            ))
-                            .width(Length::Fill)
-                            .height(Length::Fill)
-                            .spacing(spacing.space_xs),
-                    )
-                    .push(
-                        widget::row::with_capacity(4)
-                            .push(self.button(
-                                Message::Operator(Operator::ParenthesesOpen),
-                                theme::Button::Standard,
-                            ))
-                            .push(self.button(
-                                Message::Operator(Operator::ParenthesesClose),
-                                theme::Button::Standard,
-                            ))
-                            .push(self.button(
-                                Message::Operator(Operator::SquareRoot),
-                                theme::Button::Standard,
-                            ))
-                            .push(self.button(
-                                Message::Operator(Operator::Divide),
-                                theme::Button::Suggested,
-                            ))
-                            .width(Length::Fill)
-                            .height(Length::Fill)
-                            .spacing(spacing.space_xs),
-                    )
-                    .push(
-                        widget::row::with_capacity(4)
-                            .push(self.button(Message::Number(7.0), theme::Button::Text))
-                            .push(self.button(Message::Number(8.0), theme::Button::Text))
-                            .push(self.button(Message::Number(9.0), theme::Button::Text))
-                            .push(self.button(
-                                Message::Operator(Operator::Multiply),
-                                theme::Button::Suggested,
-                            ))
-                            .width(Length::Fill)
-                            .height(Length::Fill)
-                            .spacing(spacing.space_xs),
-                    )
-                    .push(
-                        widget::row::with_capacity(4)
-                            .push(self.button(Message::Number(4.0), theme::Button::Text))
-                            .push(self.button(Message::Number(5.0), theme::Button::Text))
-                            .push(self.button(Message::Number(6.0), theme::Button::Text))
-                            .push(self.button(
-                                Message::Operator(Operator::Subtract),
-                                theme::Button::Suggested,
-                            ))
-                            .width(Length::Fill)
-                            .height(Length::Fill)
-                            .spacing(spacing.space_xs),
-                    )
-                    .push(
-                        widget::row::with_capacity(4)
-                            .push(self.button(Message::Number(1.0), theme::Button::Text))
-                            .push(self.button(Message::Number(2.0), theme::Button::Text))
-                            .push(self.button(Message::Number(3.0), theme::Button::Text))
-                            .push(
-                                self.button(
-                                    Message::Operator(Operator::Add),
-                                    theme::Button::Suggested,
-                                ),
-                            )
-                            .width(Length::Fill)
-                            .height(Length::Fill)
-                            .spacing(spacing.space_xs),
-                    )
-                    .push(
-                        widget::row::with_capacity(4)
-                            .push(self.button(Message::Number(0.0), theme::Button::Text))
-                            .push(
-                                self.button(
-                                    Message::Operator(Operator::Point),
-                                    theme::Button::Text,
-                                ),
-                            )
-                            .push(self.button(
-                                Message::Operator(Operator::Backspace),
-                                theme::Button::Destructive,
-                            ))
-                            .push(self.button(
-                                Message::Operator(Operator::Equal),
-                                theme::Button::Suggested,
-                            ))
-                            .width(Length::Fill)
-                            .height(Length::Fill)
-                            .spacing(spacing.space_xs),
-                    )
-                    .push(widget::row(vec![widget::toaster(
-                        &self.toasts,
-                        widget::space::horizontal(),
-                    )]))
-                    .max_width(1000.0)
-                    .width(Length::Fill)
-                    .height(Length::Fill)
-                    .align_x(Alignment::Center)
-                    .spacing(spacing.space_xs),
-            )
+            .push(keypad)
             .align_x(Alignment::Center)
             .spacing(spacing.space_s)
             .padding(spacing.space_xxs)
@@ -561,6 +579,9 @@ impl Application for CosmicCalculator {
                         ")" => Some(Operator::ParenthesesClose),
                         "^" => Some(Operator::Power),
                         "=" => Some(Operator::Equal),
+                        "√" => Some(Operator::SquareRoot),
+                        "!" => Some(Operator::Factorial),
+                        "π" => Some(Operator::Pi),
                         _ => None,
                     };
                     if let Some(operator) = operator {
@@ -632,6 +653,7 @@ impl Application for CosmicCalculator {
             Message::Resized(size) => {
                 self.button_font_size = (size.height / 22.0).clamp(10.0, 48.0);
             }
+            Message::ToggleScientificMode => self.scientific_mode = !self.scientific_mode,
         }
         Task::batch(tasks)
     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -124,7 +124,7 @@ impl CosmicCalculator {
 
         let label = match &message {
             Message::Number(num) => num.to_string(),
-            Message::Operator(operator) => operator.display().to_string(),
+            Message::Operator(operator) => operator.display(self.calculator.decimal_comma).to_string(),
             _ => String::new(),
         };
 

--- a/src/app/operations.rs
+++ b/src/app/operations.rs
@@ -29,7 +29,7 @@ impl Calculator {
     }
 
     pub fn add_operator(&mut self, operator: Operator) {
-        self.expression.push_str(operator.expression());
+        self.expression.push_str(operator.expression(self.decimal_comma));
     }
 
     pub fn on_number_press(&mut self, number: f32) {
@@ -121,6 +121,7 @@ impl Calculator {
                         | '%'
                         | '.'
                         | ','
+                        | ';'
                         | '('
                         | ')'
                         | '^'

--- a/src/app/operations.rs
+++ b/src/app/operations.rs
@@ -47,7 +47,21 @@ impl Calculator {
             | Operator::ParenthesesOpen
             | Operator::ParenthesesClose
             | Operator::Power
-            | Operator::SquareRoot => self.add_operator(operator.clone()),
+            | Operator::SquareRoot
+            | Operator::Comma
+            | Operator::Log
+            | Operator::Ln
+            | Operator::Log2
+            | Operator::Factorial
+            | Operator::Sin
+            | Operator::Cos
+            | Operator::Tan
+            | Operator::Asin 
+            | Operator::Acos 
+            | Operator::Atan
+            | Operator::Pi
+            | Operator::E
+            | Operator::Reciprocal => self.add_operator(operator.clone()),
 
             Operator::Clear => self.clear(),
             Operator::Negate => self.toggle_sign(),

--- a/src/app/operator.rs
+++ b/src/app/operator.rs
@@ -14,6 +14,21 @@ pub enum Operator {
     ParenthesesClose,
     Power,
     SquareRoot,
+    // Scientific
+    Comma,
+    Log,
+    Ln,
+    Log2,
+    Factorial,
+    Sin,
+    Cos,
+    Tan,
+    Asin,
+    Acos,
+    Atan,
+    Pi,
+    E,
+    Reciprocal,
 }
 
 impl Operator {
@@ -33,6 +48,21 @@ impl Operator {
             Self::Clear => "C",
             Self::Backspace => "⌫",
             Self::Negate => "±",
+            // Scientific
+            Self::Comma => ",",
+            Self::Log => "log",
+            Self::Ln => "ln",
+            Self::Log2 => "log2",
+            Self::Factorial => "!",
+            Self::Sin => "sin",
+            Self::Cos => "cos",
+            Self::Tan => "tan",
+            Self::Asin => "asin",
+            Self::Acos => "acos",
+            Self::Atan => "atan",
+            Self::Pi => "π",
+            Self::E => "e",
+            Self::Reciprocal => "1/x",
         }
     }
 
@@ -52,6 +82,20 @@ impl Operator {
             Self::Clear => "C",
             Self::Backspace => "⌫",
             Self::Negate => "±",
+            Self::Comma => ",",
+            Self::Log => "log",
+            Self::Ln => "ln",
+            Self::Log2 => "log2",
+            Self::Factorial => "!",
+            Self::Sin => "sin",
+            Self::Cos => "cos",
+            Self::Tan => "tan",
+            Self::Asin => "asin",
+            Self::Acos => "acos",
+            Self::Atan => "atan",
+            Self::Pi => "π",
+            Self::E => "e",
+            Self::Reciprocal => "⁻¹",
         }
     }
 }

--- a/src/app/operator.rs
+++ b/src/app/operator.rs
@@ -32,14 +32,14 @@ pub enum Operator {
 }
 
 impl Operator {
-    pub fn display(&self) -> &str {
+    pub fn display(&self, decimal_comma: bool) -> &str {
         match self {
             Self::Add => "+",
             Self::Subtract => "-",
             Self::Multiply => "x",
             Self::Divide => "÷",
             Self::Modulus => "%",
-            Self::Point => ".",
+            Self::Point => if decimal_comma {","} else {"."},
             Self::Equal => "=",
             Self::ParenthesesOpen => "(",
             Self::ParenthesesClose => ")",
@@ -49,7 +49,7 @@ impl Operator {
             Self::Backspace => "⌫",
             Self::Negate => "±",
             // Scientific
-            Self::Comma => ",",
+            Self::Comma => if decimal_comma {";"} else {","},
             Self::Log => "log",
             Self::Ln => "ln",
             Self::Log2 => "log2",
@@ -66,14 +66,14 @@ impl Operator {
         }
     }
 
-    pub fn expression(&self) -> &str {
+    pub fn expression(&self, decimal_comma: bool) -> &str {
         match self {
             Self::Add => "+",
             Self::Subtract => "-",
             Self::Multiply => "*",
             Self::Divide => "/",
             Self::Modulus => "%",
-            Self::Point => ".",
+            Self::Point => if decimal_comma {","} else {"."},
             Self::Equal => "=",
             Self::ParenthesesOpen => "(",
             Self::ParenthesesClose => ")",
@@ -82,10 +82,10 @@ impl Operator {
             Self::Clear => "C",
             Self::Backspace => "⌫",
             Self::Negate => "±",
-            Self::Comma => ",",
+            Self::Comma => if decimal_comma {";"} else {","},
             Self::Log => "log",
             Self::Ln => "ln",
-            Self::Log2 => "log2",
+            Self::Log2 => "log2(",
             Self::Factorial => "!",
             Self::Sin => "sin",
             Self::Cos => "cos",


### PR DESCRIPTION
#1

- Add initial support for scientific mode.
- Align calculator display input handling with the system's decimal separator settings.
- Fix the keypad not updating correctly in locales that use a comma as the decimal separator.