### PR TITLE
improv: normalize math symbols to unicode and rename operators

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -368,7 +368,7 @@ impl Application for CosmicCalculator {
                     .push(self.button(Message::Operator(Operator::Clear), theme::Button::Destructive))
                     .push(self.button(Message::Operator(Operator::Negate), theme::Button::Standard))
                     .push(self.button(Message::Operator(Operator::Modulus), theme::Button::Standard))
-                    .push(self.button(Message::Operator(Operator::Power), theme::Button::Suggested))
+                    .push(self.button(Message::Operator(Operator::Exponent), theme::Button::Suggested))
                     .width(Length::Fill)
                     .height(Length::Fill)
                     .spacing(spacing.space_xs),
@@ -416,7 +416,7 @@ impl Application for CosmicCalculator {
             .push(
                 widget::row::with_capacity(4)
                     .push(self.button(Message::Number(0.0), theme::Button::Text))
-                    .push(self.button(Message::Operator(Operator::Point), theme::Button::Text))
+                    .push(self.button(Message::Operator(Operator::DecimalSeparator), theme::Button::Text))
                     .push(self.button(Message::Operator(Operator::Backspace), theme::Button::Destructive))
                     .push(self.button(Message::Operator(Operator::Equal), theme::Button::Suggested))
                     .width(Length::Fill)
@@ -588,13 +588,13 @@ impl Application for CosmicCalculator {
                 if let Some(c) = character {
                     let operator = match c.as_str() {
                         "+" => Some(Operator::Add),
-                        "-" => Some(Operator::Subtract),
+                        "-" | "−" => Some(Operator::Subtract),
                         "*" | "×" => Some(Operator::Multiply),
                         "/" | "÷" => Some(Operator::Divide),
                         "%" => Some(Operator::Modulus),
                         "(" => Some(Operator::ParenthesesOpen),
                         ")" => Some(Operator::ParenthesesClose),
-                        "^" => Some(Operator::Power),
+                        "^" => Some(Operator::Exponent),
                         "=" => Some(Operator::Equal),
                         "√" => Some(Operator::SquareRoot),
                         "!" => Some(Operator::Factorial),
@@ -695,7 +695,12 @@ impl Application for CosmicCalculator {
 
         let subscriptions = vec![
             event::listen_with(|event, status, _id| match event {
-                Event::Keyboard(KeyEvent::KeyPressed { key, modifiers, text, .. }) => match status {
+                Event::Keyboard(KeyEvent::KeyPressed {
+                    key,
+                    modifiers,
+                    text,
+                    ..
+                }) => match status {
                     event::Status::Ignored => {
                         Some(Message::Key(modifiers, key, text.map(|t| t.to_string())))
                     }

--- a/src/app/operations.rs
+++ b/src/app/operations.rs
@@ -43,10 +43,10 @@ impl Calculator {
             | Operator::Multiply
             | Operator::Divide
             | Operator::Modulus
-            | Operator::Point
+            | Operator::DecimalSeparator
             | Operator::ParenthesesOpen
             | Operator::ParenthesesClose
-            | Operator::Power
+            | Operator::Exponent
             | Operator::SquareRoot
             | Operator::Comma
             | Operator::Log
@@ -56,8 +56,8 @@ impl Calculator {
             | Operator::Sin
             | Operator::Cos
             | Operator::Tan
-            | Operator::Asin 
-            | Operator::Acos 
+            | Operator::Asin
+            | Operator::Acos
             | Operator::Atan
             | Operator::Pi
             | Operator::E
@@ -87,16 +87,28 @@ impl Calculator {
 
         let before = &self.expression[..num_start];
         // A '-' is unary at the start or right after an operator or '('.
-        let is_unary_minus = before.ends_with('-')
-            && matches!(
-                before[..before.len() - 1].chars().next_back(),
-                None | Some('+' | '-' | '*' | '/' | '×' | '÷' | '%' | '^' | '(')
-            );
+        // Checks for both ASCII '-' and Unicode '−' for unary detection.
+        let is_unary_minus = before.ends_with('−')
+            || before.ends_with('-')
+                && matches!(
+                    before[..before.len() - 1].chars().next_back(),
+                    None | Some('+' | '-' | '−' | '*' | '/' | '×' | '÷' | '%' | '^' | '(')
+                );
 
         if is_unary_minus {
-            self.expression.remove(num_start - 1);
+            // Remove the last character (the minus sign)
+            // Handle both ASCII and Unicode length correctly
+            if before.ends_with('−') {
+                // Unicode minus is 3 bytes in UTF-8, but .remove takes char index
+                // We need to find the char index of the minus
+                if let Some(minus_idx) = before.char_indices().rev().next().map(|(i, _)| i) {
+                    self.expression.remove(minus_idx);
+                }
+            } else {
+                self.expression.remove(num_start - 1);
+            }
         } else {
-            self.expression.insert(num_start, '-');
+            self.expression.insert(num_start, '−'); // Use Unicode minus for consistency
         }
     }
 
@@ -106,18 +118,36 @@ impl Calculator {
     }
 
     pub(crate) fn on_input(&mut self, input: String) {
+        let normalized_input = input
+            // Multiplication to Unicode Multiplication Sign
+            // Note: '.' (period) is preserved for decimals (e.g., 3.14).
+            // '·' (Middle Dot, U+00B7) is distinct and used for multiplication.
+            .replace('*', "×")
+            .replace('x', "×")
+            .replace('X', "×")
+            .replace('·', "×") // Middle Dot
+            // Division to Unicode Division Sign
+            .replace('/', "÷")
+            .replace(':', "÷")
+            // Power
+            .replace("**", "^")
+            // Dashes to Unicode Minus Sign
+            .replace('-', "−") // Hyphen-Minus
+            .replace('–', "−") // En Dash
+            .replace('—', "−"); // Em Dash
+
         // qalc validates the expression itself, so keep this filter permissive:
         // allow letters (sin, pi), whitespace, '!', and ',' for decimal-comma locales.
-        if input.chars().all(|c| {
+        // Normalized Unicode symbols (−, ×, ÷) are now expected.
+        if normalized_input.chars().all(|c| {
             c.is_alphanumeric()
                 || c.is_whitespace()
                 || matches!(
                     c,
-                    '+' | '-'
-                        | '*'
+                    '+' | '−'
+                        | '×'
                         | '/'
                         | '÷'
-                        | '×'
                         | '%'
                         | '.'
                         | ','
@@ -130,7 +160,7 @@ impl Calculator {
                         | '\u{8}'
                 )
         }) {
-            self.expression = input;
+            self.expression = normalized_input;
         }
     }
 }

--- a/src/app/operator.rs
+++ b/src/app/operator.rs
@@ -5,14 +5,14 @@ pub enum Operator {
     Multiply,
     Divide,
     Modulus,
-    Point,
+    DecimalSeparator,
     Equal,
     Clear,
     Backspace,
     Negate,
     ParenthesesOpen,
     ParenthesesClose,
-    Power,
+    Exponent,
     SquareRoot,
     // Scientific
     Comma,
@@ -35,15 +35,15 @@ impl Operator {
     pub fn display(&self, decimal_comma: bool) -> &str {
         match self {
             Self::Add => "+",
-            Self::Subtract => "-",
-            Self::Multiply => "x",
-            Self::Divide => "÷",
+            Self::Subtract => "−", // Unicode Minus Sign
+            Self::Multiply => "×", // Unicode Multiplication Sign
+            Self::Divide => "÷",   // Unicode Division Sign
             Self::Modulus => "%",
-            Self::Point => if decimal_comma {","} else {"."},
+            Self::DecimalSeparator => if decimal_comma {","} else {"."},
             Self::Equal => "=",
             Self::ParenthesesOpen => "(",
             Self::ParenthesesClose => ")",
-            Self::Power => "^",
+            Self::Exponent => "xʸ",
             Self::SquareRoot => "√",
             Self::Clear => "C",
             Self::Backspace => "⌫",
@@ -69,15 +69,15 @@ impl Operator {
     pub fn expression(&self, decimal_comma: bool) -> &str {
         match self {
             Self::Add => "+",
-            Self::Subtract => "-",
-            Self::Multiply => "*",
-            Self::Divide => "/",
+            Self::Subtract => "−", // Unicode Minus Sign
+            Self::Multiply => "×", // Unicode Multiplication Sign
+            Self::Divide => "÷",   // Unicode Division Sign
             Self::Modulus => "%",
-            Self::Point => if decimal_comma {","} else {"."},
+            Self::DecimalSeparator => if decimal_comma {","} else {"."},
             Self::Equal => "=",
             Self::ParenthesesOpen => "(",
             Self::ParenthesesClose => ")",
-            Self::Power => "^",
+            Self::Exponent => "^",
             Self::SquareRoot => "√",
             Self::Clear => "C",
             Self::Backspace => "⌫",


### PR DESCRIPTION
This PR improves the typographic quality of the calculator by standardizing mathematical symbols to their proper Unicode equivalents and clarifying operator naming.

## Changes
- **Unicode Normalization:** Replaces ASCII operators (`-`, `x`, `/`) with proper math symbols (`−`, `×`, `÷`) in both display and internal expression handling.
- **Input Robustness:** Implements input normalization to automatically convert common typing variations (e.g., letter `x`, en-dash `–`, asterisk `*`) into their correct mathematical symbols.
- **Naming Clarity:** Renames `Operator::Power` to `Exponent` and `Operator::Point` to `DecimalSeparator` for better code semantics.
- **Keyboard Support:** Updates keyboard bindings to recognize Unicode symbols directly (e.g., typing `−` or `×` works immediately).
- **Unary Minus Fix:** Enhances the `±` toggle logic to correctly detect and handle both ASCII and Unicode minus signs.

### Note
The `DecimalSeparator` button currently displays and inserts a dot (`.`). Dynamic localization based on system region settings is reserved for a future PR to keep this change focused on typography and code structure.

## Screenshots (before/after)
<img width="270" height="450" alt="before" src="https://github.com/user-attachments/assets/29b3797f-8670-4e1e-9be8-59a6ca926330" /><img width="270" height="450" alt="after" src="https://github.com/user-attachments/assets/b6520833-e213-46a0-8208-e009f0d0410a" />